### PR TITLE
lombok の setter が不要になったので削除。

### DIFF
--- a/src/main/java/com/kasakaid/kasakaidboot/application/MusicFestivalService.java
+++ b/src/main/java/com/kasakaid/kasakaidboot/application/MusicFestivalService.java
@@ -51,7 +51,7 @@ public class MusicFestivalService {
     }
 
     private MusicFestival transformArtist(MusicFestival festival) {
-        festival.setArtists(
+        festival.storeArtistsList(
                 festival.getArtists().stream().map((FestivalArtist festivalArtist) -> {
                     if (festivalArtist.getArtist() instanceof ArtistTransformer) {
                         festivalArtist.renewArtists((ArtistTransformer) festivalArtist.getArtist());

--- a/src/main/java/com/kasakaid/kasakaidboot/domain/MusicFestival.java
+++ b/src/main/java/com/kasakaid/kasakaidboot/domain/MusicFestival.java
@@ -4,7 +4,6 @@ import com.kasakaid.kasakaidboot.utility.LocalDateConverter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -73,9 +72,12 @@ public class MusicFestival {
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "musicFestival")
     @Getter
-    @Setter
     @OrderBy("playOrder ASC")
     private List<FestivalArtist> artists;
+
+    private void setArtists(List<FestivalArtist> artists) {
+        this.artists = artists;
+    }
 
     public boolean storeArtistsList(List<FestivalArtist> artists) {
         setArtists(artists);

--- a/src/test/java/com/kasakaid/kasakaidboot/repository/MusicFestivalRepositoryTest.java
+++ b/src/test/java/com/kasakaid/kasakaidboot/repository/MusicFestivalRepositoryTest.java
@@ -44,7 +44,7 @@ public class MusicFestivalRepositoryTest {
         FestivalArtist festivalArtist = FestivalArtist.of().festivalId(3L).artistId(5L)
                 .playOrder(5).start(
                  LocalDateTime.of(2017, Month.AUGUST, 5, 14, 0, 0)).artist(solo).build();
-        festival.setArtists(new ArrayList()
+        festival.storeArtistsList(new ArrayList()
                 {
                         {
                                 add(festivalArtist);


### PR DESCRIPTION
イミュータブルでデータをフィルタリングする際に、true/false で返す必要が生じた。
setter を使ってセットすると値を返さないので、@setter は削除して、true を返すメソッドで代替した。
https://github.com/kadtewsd/kasakaidBoot/pull/11/commits/22fae9bcd95f9b65007e553af0a1bd0a8dcf751e